### PR TITLE
NGSTACK-999 upgrade bundle to ibexa version 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        symfony: ['~5.4.0']
+        php: ['8.3']
+        symfony: ['~7.3.0']
         phpunit: ['phpunit.xml']
         deps: ['normal']
-        include:
-          - php: '7.4'
-            symfony: '~5.4.0'
-            phpunit: 'phpunit.xml'
-            deps: 'low'
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .phpunit.result.cache
 composer.lock
 vendor
+.phpunit.cache

--- a/bundle/Core/FieldType/Birthday/Type.php
+++ b/bundle/Core/FieldType/Birthday/Type.php
@@ -18,15 +18,9 @@ use function is_string;
 
 final class Type extends FieldType
 {
-    /**
-     * @const int
-     */
-    public const DEFAULT_VALUE_EMPTY = 0;
+    public const int DEFAULT_VALUE_EMPTY = 0;
 
-    /**
-     * @const int
-     */
-    public const DEFAULT_VALUE_CURRENT_DATE = 1;
+    public const int DEFAULT_VALUE_CURRENT_DATE = 1;
 
     /**
      * @var array<string, array<string, mixed>>
@@ -75,7 +69,7 @@ final class Type extends FieldType
      *
      * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): mixed
     {
         return (string) $value;
     }
@@ -159,7 +153,7 @@ final class Type extends FieldType
         }
     }
 
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(BaseValue $value): string
     {
         return (string) $value;
     }

--- a/bundle/Core/FieldType/Birthday/Value.php
+++ b/bundle/Core/FieldType/Birthday/Value.php
@@ -12,8 +12,6 @@ use function is_string;
 
 final class Value extends BaseValue
 {
-    public ?DateTimeImmutable $date = null;
-
     /**
      * Date format to be used by {@link __toString()}.
      */
@@ -22,9 +20,9 @@ final class Value extends BaseValue
     /**
      * Construct a new Value object and initialize with $dateTime.
      *
-     * @param \DateTimeInterface|string|null $date Date as a DateTime object or string in Y-m-d format
+     * @param DateTimeImmutable|string|null $date Date as a DateTime object or string in Y-m-d format
      */
-    public function __construct($date = null)
+    public function __construct(public DateTimeImmutable|string|null $date = null)
     {
         if ($date instanceof DateTimeImmutable) {
             $this->date = $date->setTime(0, 0);

--- a/bundle/Core/FieldType/Birthday/Value.php
+++ b/bundle/Core/FieldType/Birthday/Value.php
@@ -12,6 +12,8 @@ use function is_string;
 
 final class Value extends BaseValue
 {
+    public ?DateTimeImmutable $date = null;
+
     /**
      * Date format to be used by {@link __toString()}.
      */
@@ -20,9 +22,9 @@ final class Value extends BaseValue
     /**
      * Construct a new Value object and initialize with $dateTime.
      *
-     * @param DateTimeImmutable|string|null $date Date as a DateTime object or string in Y-m-d format
+     * @param DateTimeInterface|string|null $date Date as a DateTime object or string in Y-m-d format
      */
-    public function __construct(public DateTimeImmutable|string|null $date = null)
+    public function __construct(DateTimeInterface|string|null $date = null)
     {
         if ($date instanceof DateTimeImmutable) {
             $this->date = $date->setTime(0, 0);

--- a/bundle/Core/Persistence/Legacy/Content/FieldValue/Converter/Birthday.php
+++ b/bundle/Core/Persistence/Legacy/Content/FieldValue/Converter/Birthday.php
@@ -39,7 +39,7 @@ final class Birthday implements Converter
         );
     }
 
-    public function getIndexColumn()
+    public function getIndexColumn(): string
     {
         return 'sort_key_string';
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "twig/intl-extra": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.0"
+        "phpunit/phpunit": "^12.0",
+        "netgen/ibexa-forms-bundle": "^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "twig/intl-extra": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.0",
-        "symfony/form": "^7.3"
+        "phpunit/phpunit": "^12.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "ibexa/core": "^4.0",
+        "ibexa/core": "^5.0",
         "twig/intl-extra": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "netgen/ibexa-forms-bundle": "^4.0"
+        "phpunit/phpunit": "^12.0",
+        "symfony/form": "^7.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,29 @@
-<phpunit bootstrap="vendor/autoload.php"
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         cacheDirectory=".phpunit.cache"
+         requireCoverageMetadata="true"
 >
     <testsuites>
         <testsuite name="Netgen\BirthdayBundle\Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">bundle</directory>
-            <exclude>
-                <directory>bundle/DependencyInjection</directory>
-                <directory>bundle/Resources</directory>
-                <directory>bundle/extension</directory>
-                <file>bundle/NetgenBirthdayBundle.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>bundle/DependencyInjection</directory>
+            <directory>bundle/Resources</directory>
+            <directory>bundle/extension</directory>
+            <file>bundle/NetgenBirthdayBundle.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/tests/Core/FieldType/Birthday/TypeTest.php
+++ b/tests/Core/FieldType/Birthday/TypeTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Netgen\Bundle\BirthdayBundle\Tests\Core\FieldType\Birthday;
 
 use DateTimeImmutable;
-use Ibexa\Contracts\Core\FieldType\FieldType;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Netgen\Bundle\BirthdayBundle\Core\FieldType\Birthday\Type;
 use Netgen\Bundle\BirthdayBundle\Core\FieldType\Birthday\Value;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Type::class)]
 final class TypeTest extends TestCase
 {
     private Type $type;
@@ -19,11 +20,6 @@ final class TypeTest extends TestCase
     protected function setUp(): void
     {
         $this->type = new Type();
-    }
-
-    public function testInstanceOfFieldType(): void
-    {
-        self::assertInstanceOf(FieldType::class, $this->type);
     }
 
     public function testIsSearchable(): void

--- a/tests/Core/FieldType/Birthday/ValueTest.php
+++ b/tests/Core/FieldType/Birthday/ValueTest.php
@@ -7,8 +7,10 @@ namespace Netgen\Bundle\BirthdayBundle\Tests\Core\FieldType\Birthday;
 use DateTimeImmutable;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use Netgen\Bundle\BirthdayBundle\Core\FieldType\Birthday\Value;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Value::class)]
 final class ValueTest extends TestCase
 {
     public function testInstanceOfValue(): void

--- a/tests/Core/Persistence/Legacy/Content/FieldValue/Converter/BirthdayTest.php
+++ b/tests/Core/Persistence/Legacy/Content/FieldValue/Converter/BirthdayTest.php
@@ -10,8 +10,10 @@ use Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 use Netgen\Bundle\BirthdayBundle\Core\Persistence\Legacy\Content\FieldValue\Converter\Birthday;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Birthday::class)]
 final class BirthdayTest extends TestCase
 {
     private Birthday $converter;

--- a/tests/Form/FieldTypeHandler/BirthdayTest.php
+++ b/tests/Form/FieldTypeHandler/BirthdayTest.php
@@ -9,9 +9,11 @@ use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Netgen\Bundle\BirthdayBundle\Core\FieldType\Birthday\Value;
 use Netgen\Bundle\BirthdayBundle\Form\FieldTypeHandler\Birthday;
 use Netgen\Bundle\IbexaFormsBundle\Form\FieldTypeHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[CoversClass(Birthday::class)]
 final class BirthdayTest extends TestCase
 {
     private Birthday $handler;
@@ -66,7 +68,7 @@ final class BirthdayTest extends TestCase
 
         $fieldDefinition = new FieldDefinition(
             [
-                'id' => 'id',
+                'id' => 123,
                 'identifier' => 'identifier',
                 'isRequired' => true,
                 'descriptions' => ['fre-FR' => 'fre-FR'],


### PR DESCRIPTION
Upgraded bundle to use Ibexa version 5. Also added `symfony/form` bundle in 'require-dev' section because it is used by [`Birthday`](https://github.com/netgen/NetgenBirthdayBundle/blob/master/bundle/Form/FieldTypeHandler/Birthday.php) class. For now, I've removed the `netgen/ibexa-forms-bundle` bundle because it is not yet upgraded to IbexaV5.

In code, I've added a few missing return types for some methods and types for constants. Also used constructor promotion in one class. 

Upgraded tests to be compatible with PHP8 and PHPUnit12 - this mainly involved upgrading the `@covers` annotations to `#[Covers]` attributes.